### PR TITLE
Change the span kv log position to correct the committers numbers

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,10 +24,10 @@ def clean_github_data(repo_contributors):
     with tracer.start_span("clean_github_data", child_of=get_current_span()) as span:
         contributors_to_commit = {}
         bad_thing_1()
-        span.log_kv({"repo_contributors_size": len(contributors_to_commit)})
         for contribute in repo_contributors:
             username = contribute["author"]["login"]
             contributors_to_commit[username] = sum((week["c"] for week in contribute["weeks"]))
+        span.log_kv({"repo_contributors_size": len(contributors_to_commit)})
         return contributors_to_commit
 
 


### PR DESCRIPTION
Existing code always shows code-committers as 0 since the dictionary is empty.
Moved the span.log_kv() line to post populating the dictionary to correct this behaviour